### PR TITLE
Fix syntax errors in analysis notebook and improve README clarity

### DIFF
--- a/Police_Dataset_Analysis.ipynb
+++ b/Police_Dataset_Analysis.ipynb
@@ -370,20 +370,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 54,
+   "cell_type": "markdown",
    "id": "aef4311f-9678-4401-871e-aece7278557b",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (3795414970.py, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;36m  Cell \u001b[1;32mIn[54], line 1\u001b[1;36m\u001b[0m\n\u001b[1;33m    **Remove the columns that only contains null values**\u001b[0m\n\u001b[1;37m    ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
    "source": [
     "**Remove the columns that only contains null values**"
    ]
@@ -736,20 +725,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 52,
+   "cell_type": "markdown",
    "id": "8369a8be-9988-4f61-9326-29a649e9d7cd",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (2005368382.py, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;36m  Cell \u001b[1;32mIn[52], line 1\u001b[1;36m\u001b[0m\n\u001b[1;33m    **For speeding were man or women stopped more often?**\u001b[0m\n\u001b[1;37m    ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
    "source": [
     "**For speeding were man or women stopped more often?**"
    ]
@@ -944,20 +922,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 78,
+   "cell_type": "markdown",
    "id": "01807707-1a78-49c1-a262-fd4209c2b8f8",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (1486425893.py, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;36m  Cell \u001b[1;32mIn[78], line 1\u001b[1;36m\u001b[0m\n\u001b[1;33m    **Does gender affect who gets searched during a stop?**\u001b[0m\n\u001b[1;37m    ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
    "source": [
     "**Does gender affect who gets searched during a stop?**"
    ]
@@ -1011,20 +978,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 94,
+   "cell_type": "markdown",
    "id": "28249d2e-52df-4120-879e-7ed466d109a6",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (707445007.py, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;36m  Cell \u001b[1;32mIn[94], line 1\u001b[1;36m\u001b[0m\n\u001b[1;33m    **What is the mean stopped_time**\u001b[0m\n\u001b[1;37m    ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
    "source": [
     "**What is the mean stopped_time**"
    ]
@@ -1584,20 +1540,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 189,
+   "cell_type": "markdown",
    "id": "029788ca-a252-435c-a53d-f8f4ae8f8cfb",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (2463160572.py, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;36m  Cell \u001b[1;32mIn[189], line 1\u001b[1;36m\u001b[0m\n\u001b[1;33m    **Compare the age distributions for each violation**\u001b[0m\n\u001b[1;37m    ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
    "source": [
     "**Compare the age distributions for each violation**"
    ]
@@ -1749,14 +1694,6 @@
    "source": [
     "data.groupby(\"violation\").driver_age.describe()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b58992a1-06a8-48f7-823e-e013f6360c66",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Police Dataset Analysis
+# Police Dataset Analysis Project
 
 This project provides a comprehensive analysis of a police stop dataset using Python and Pandas. The primary goal is to clean, transform, and explore the data to uncover patterns and insights related to law enforcement activities.
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
-# Police_Dataset_Analysis
-The Police Dataset Analysis project utilizes Python and Pandas to process and analyze a dataset related to police activities. The project focuses on data cleaning, transformation, and extracting insights to understand patterns in law enforcement operations.
+# Police Dataset Analysis
 
-**Features**
+This project provides a comprehensive analysis of a police stop dataset using Python and Pandas. The primary goal is to clean, transform, and explore the data to uncover patterns and insights related to law enforcement activities.
 
-Data Cleaning: Handling missing values and dropping unnecessary columns.
+## Project Overview
 
-Data Transformation: Converting data types and standardizing formats.
+- **Data Cleaning:** Handles missing values and removes columns with only null values to ensure data quality.
+- **Data Transformation:** Standardizes and converts data types, including mapping categorical durations to numeric values for analysis.
+- **Exploratory Data Analysis (EDA):** Examines trends such as the frequency of stops by gender, the impact of gender on search likelihood, and the distribution of stop durations.
+- **Statistical Analysis:** Calculates descriptive statistics (mean, value counts, etc.) for key variables, including stop duration and driver age by violation type.
 
-Exploratory Data Analysis (EDA): Identifying trends and patterns in police activities.
+## Technologies Used
 
-Statistical Analysis: Calculating key metrics such as mean, median, and standard deviation.
+- **Python:** Core programming language for data analysis.
+- **Pandas:** Library for data manipulation and cleaning.
+- **Jupyter Notebook:** Interactive environment for step-by-step analysis and visualization.
 
-**Technologies Used**
+## How to Use
 
-Python (for data processing and analysis)
+1. Ensure the dataset file (`Police dataset.csv`) is present in the project directory.
+2. Open `Police_Dataset_Analysis.ipynb` in Jupyter Notebook or Visual Studio Code.
+3. Run the notebook cells in order to perform data cleaning, transformation, and analysis.
 
-Pandas (for data manipulation and cleaning)
+## Future Enhancements
 
-Jupyter Notebook (for interactive development and visualization)
+- Integrate machine learning models for predictive analytics.
+- Develop interactive dashboards using visualization tools such as Power BI or Metabase.
+- Expand the dataset for broader and deeper insights.
 
-**Future Improvements**
+## License
 
-Implementing machine learning models for predictive analysis.
-
-Creating interactive dashboards using Power BI or Metabase.
-
-Expanding dataset coverage for deeper insights.
+This project is intended for educational and analytical purposes only.


### PR DESCRIPTION
Convert code cells to markdown in the analysis notebook to eliminate syntax errors and enhance readability. Refactor the README.md for better structure and clarity, providing a clearer overview of the project and its features.